### PR TITLE
Add codiceIPA to the publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -38,6 +38,9 @@ localisation:
   availableLanguages:
     - it
 it:
+  countryExtensionVersion: '0.2'
+  riuso:
+    codiceIPA: p_tn
   piattaforme:
     spid: false
   conforme:


### PR DESCRIPTION
Questa PR:
* Aggiunge il codice IPA nella sezione riuso del publiccode.yml

In questo modo sarà possibile vedere il software indicizzato nella parte superiore del catalogo riservata alle PA (e non quella inferiore). 

@marcomb 
Grazie